### PR TITLE
Create initial password and set to require change on first login (then no longer controlled through puppet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for reference if you wish to use it.
 The way to use this module is always to invoke the `virtual_user` resource as
 a virtual and then "realize" it on the systems you want the user accounts on.
 
-At it's simpliest, you can define a user account as per the following example:
+At it's simplest, you can define a user account as per the following example:
 
     # Define virtual user Jane. This means Jane won't be applied, unless we
     # realise her later on.
@@ -28,17 +28,37 @@ At it's simpliest, you can define a user account as per the following example:
     # our Jane example from above and ensure she has an account on this server.
     Virtual_user <| tags == soe |>
 
+If you set `puppet_controlled_pw => false` the module will create an initial 
+password specified as a hash in `password_hash` and configure the account to 
+require a new password to be set on first login. If the password is not changed
+within 7 days (default), the account is disabled. This allows users to control 
+their own passwords separately from puppet. If you do not set `password_hash`,
+a default of `this.is.insecure` will be used. Example:
+
+    # Define virtual user Jane. This means Jane won't be applied, unless we
+    # realise her later on. She will have to change her password on first login.
+    # As no password_hash is defined, the default will be used. If she does not 
+    # change her password within 3 days, her account will be deactivated.
+    @virtual_user { 'jane':
+      uid                  => '1000',
+      groups               => ['wheel'],
+      puppet_controlled_pw => false,
+      inactive             => '3',
+    }
+    
+    # Here we "realize" the specific user Jane
+    realize(Virtual_user['jane'])
 
 If you want to do more complex things or tinker, check out the
-`manifests/init.pp` file for the full list of params, we make some assumptions
+`manifests/init.pp` file for the full list of params; we make some assumptions
 by default, such as creating the home directory and purging any other SSH
-authorized keys that aren't explicity configured.
+authorized keys that aren't explicitly configured.
 
 
 ## Hiera Example
 
 If you're using Hiera (recommended) then you can easily define all the user
-accounts in Hiera and use a couple lines in a Puppet manifest to generate all
+accounts in Hiera and use a couple of lines in a Puppet manifest to generate all
 the virtual users from that.
 
 The following is an example of inheriting data from Hiera with the Puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,21 +7,44 @@
 # the different resources and parameters used below.
 
 define virtual_user (
-  $username       = $name,
-  $ensure         = 'present',
-  $uid            = undef,
-  $gid            = $uid,
-  $home           = "/home/${name}",
-  $shell          = "/bin/bash",
-  $password_hash  = undef,
-  $managehome     = true,
-  $groups         = [],
-  $ssh_key_type   = undef,
-  $ssh_key_pub    = undef,
-  $ssh_key_purge  = true,
-  $tags           = [],
+  $username             = $name,
+  $ensure               = 'present',
+  $uid                  = undef,
+  $gid                  = $uid,
+  $home                 = "/home/${name}",
+  $shell                = "/bin/bash",
+  $password_hash        = undef,
+  $managehome           = true,
+  $groups               = [],
+  $ssh_key_type         = undef,
+  $ssh_key_pub          = undef,
+  $ssh_key_purge        = true,
+  $tags                 = [],
+  $password_max_age     = '17144',
+  $password_min_age     = '0',
+  $inactive             = '7',
+  $puppet_controlled_pw = true,
 ) {
 
+  if $puppet_controlled_pw {
+    if $password_hash == undef {
+      fail("A password hash for user ${username} needs to be provided for a puppet controlled password")
+    } else {
+      $firstpw = delete(chomp($password_hash), ' ') # remove any accidental whitespace from line wrapping
+      $offset  = Timestamp.new.strftime("%s") / 86400
+      $password = $firstpw
+    }
+  } else { 
+      if $password_hash == undef {
+        # Initial password is set to "this.is.insecure"
+        $firstpw = '$6$wt56xSu5$UvdMe7flLJHRuiMooXy8eE5aOVNVMZjfAPeBAafzfVYor4tWecp5UafnQ8Fm3Jbu6OpiQm.IpX.j7qFO5g9iO1'
+      } else {
+        $firstpw = $password_hash
+      }
+      # Forces new password at first login
+      $offset  = Timestamp.new.strftime("%s") / 86400 - 17145    
+  }
+    
   if (!$uid) {
     fail("A uid must be provided for user ${username}")
   }
@@ -33,15 +56,17 @@ define virtual_user (
 
   # Create the user account (and associated group).
   user { $username:
-    ensure         => $ensure,
-    uid            => $uid,
-    gid            => $gid,
-    groups         => $groups,
-    home           => $home,
-    shell          => $shell,
-    password       => delete(chomp($password_hash), ' '), # remove any accidental whitespace from line wrapping
-    managehome     => $managehome,
-    purge_ssh_keys => $ssh_key_purge,
+    ensure           => $ensure,
+    uid              => $uid,
+    gid              => $gid,
+    groups           => $groups,
+    home             => $home,
+    shell            => $shell,
+    managehome       => $managehome,
+    purge_ssh_keys   => $ssh_key_purge,
+    password_max_age => $password_max_age,
+    password_min_age => $password_max_age,
+    password         => $password,
   }
 
   group { $username:
@@ -68,9 +93,11 @@ define virtual_user (
       key    => delete(chomp($ssh_key_pub), ' '), # remove any accidental whitespace from line wrapping
     }
   }
-
-
-
+  exec { "setfirstpw_${username}":
+    command => "/usr/sbin/usermod -p '${firstpw}' $username -f $inactive ;/usr/bin/chage -d '${offset}' '${username}'",
+    onlyif => "/bin/egrep -q '^${username}:[*!]' /etc/shadow",
+    require => User[$username];
+  }
 }
 
 # vi:smartindent:tabstop=2:shiftwidth=2:expandtab:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jethrocarr-virtual_user",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "jethrocarr",
   "summary": "Very simple lightweight virtual user management module",
   "license": "Apache-2.0",


### PR DESCRIPTION
If you set `puppet_controlled_pw => false` the module will create an
initial password specified as a hash in `password_hash` and configure the
account to require a new password to be set on first login. If the
password is not changed within 7 days (default), the account is disabled.
This allows users to control their own passwords separately from puppet.